### PR TITLE
Remove trailing comma in method call

### DIFF
--- a/scripts/userTasksOverlay.js
+++ b/scripts/userTasksOverlay.js
@@ -18,7 +18,7 @@
             DOKU_BASE + 'lib/exe/ajax.php',
             {
                 call: 'plugin_do_userTasksOverlay',
-            },
+            }
         ).done(function showUserTasksOverlay(data) {
             var $wrapper = jQuery('<div class="plugin__do_usertasks_list"></div>');
             $wrapper.css({'display': 'inline-block', 'position': 'absolute'});


### PR DESCRIPTION
It turns out, this is not supported in Chrome 57 and below or in IE 11 and below. It does work in Firefox. Support in current Edge and Safari is unknown.

SPR-971