### PR TITLE
Align checkbox better in text

### DIFF
--- a/style.less
+++ b/style.less
@@ -8,7 +8,7 @@ div.dokuwiki span.plugin_do_item {
 }
 
 div.dokuwiki span.plugin_do_item a img {
-    margin-bottom: -3px;
+    margin-top: -3px;
 }
 
 div.dokuwiki span.plugin_do_done span.plugin_do_task {


### PR DESCRIPTION
In Opera 	52.0.2871.99  and Firefox 59.0.3 the checkbox does not align properly with the text on the right. By changing the margins (top to -3px, remove bottom) the checkbox does align nicely within the text

![image](https://user-images.githubusercontent.com/2140950/39811591-76fdfb0a-5389-11e8-9ef6-79dc1a61915f.png)
