### PR TITLE
Use Mailer class insted of deprecated mail_send

### DIFF
--- a/helper.php
+++ b/helper.php
@@ -354,7 +354,12 @@ class helper_plugin_do extends DokuWiki_Plugin
                 continue;
             }
             $to = $info['name'] . ' <' . $info['mail'] . '>';
-            mail_send($to, $subj, $text, $conf['mailfrom']);
+			$mail = new Mailer();
+			$mail->to($to);
+			$mail->from($conf['mailfrom']);
+			$mail->subject($subj);
+			$mail->setBody($text);
+			$mail->send();
         }
     }
 


### PR DESCRIPTION
Saving page with new task caused 500 error in the application with stack:

```
[28-May-2018 13:42:47 UTC] PHP Fatal error:  Uncaught Error: Call to a member function dump() on null in D:\DokuWiki\lib\plugins\smtp\action.php:41
Stack trace:
#0 D:\DokuWiki\inc\events.php(229): action_plugin_smtp-handle_mail_message_send(Object(Doku_Event), NULL)
#1 D:\DokuWiki\inc\events.php(70): Doku_Event_Handler->process_event(Object(Doku_Event), 'BEFORE')
#2 D:\DokuWiki\inc\events.php(106): Doku_Event->advise_before(true)
#3 D:\DokuWiki\inc\events.php(256): Doku_Event->trigger('_mail_send_acti...', true)
#4 D:\DokuWiki\inc\mail.php(105): trigger_event('MAIL_MESSAGE_SE...', Array, '_mail_send_acti...')
#5 D:\DokuWiki\lib\plugins\do\helper.php(357): mail_send('name here ...', '[subject...', 'Body...', 'fromAddr...')
#6 D:\DokuWiki\lib\plugins\do\syntax\do.php(328): helper_plugin_do->sendMail(Array, 'open', Array, 'myName')
#7 D:\DokuWiki\lib\plugins\do\syntax\do.php(193): syntax_plugin_do_do->_save(Array)
#8 D:\DokuWiki\inc\parser\renderer.php(111): syntax_plugin_do_do->render('metadata', Object(Doku_Renderer_m in D:\DokuWiki\lib\plugins\smtp\action.php on line 41
```

do plugin used deprecarted `mail_send` so I replaced it with `Mailer` class. Solution works for me.
