### PR TITLE
Allow @USER@ placeholder as user or creator in dolist

### DIFF
--- a/helper.php
+++ b/helper.php
@@ -163,6 +163,17 @@ class helper_plugin_do extends DokuWiki_Plugin
                     if (!is_array($args[$n])) {
                         $args[$n] = array($args[$n]);
                     }
+
+                    // replace current user's placeholder
+                    $args[$n] = array_map(
+                        function ($user) {
+                            return (strtolower($user) === '@user@' && $_SERVER['REMOTE_USER']) ?
+                                $_SERVER['REMOTE_USER'] :
+                                $user;
+                        },
+                        $args[$n]
+                    );
+
                     $search = $n;
 
                     /** @var DokuWiki_Auth_Plugin $auth */


### PR DESCRIPTION
Adds the ability to list tasks created by or assigned to the current user. 

The usual `@USER@` pattern in syntax is replaced with the name of the logged-in user.

Fixes #40 