### PR TITLE
added period query filter to show tasks of selected period #58

### DIFF
--- a/helper.php
+++ b/helper.php
@@ -143,7 +143,12 @@ class helper_plugin_do extends DokuWiki_Plugin
                 } elseif ($status == 'undone') {
                     $where .= ' AND B.status IS null';
                 }
+            }
 
+            if (isset($args['from']) && isset($args['to'])) {
+                $from = $args['from'][0];
+                $to =  $args['to'][0];
+                $where .= " AND A.date >= '$from' AND A.date <= '$to'";
             }
 
             if (isset($args['limit'])) {

--- a/helper.php
+++ b/helper.php
@@ -147,11 +147,11 @@ class helper_plugin_do extends DokuWiki_Plugin
 
             if (isset($args['from']) && isset($args['to'])) {
                 // regex to match YYYY-MM-DD
-                $dateRegex = '/^\d{4}-([0]\d|1[0-2])-([0-2]\d|3[01])$/';
+                $dateRegex = '/^"\d{4}-([0]\d|1[0-2])-([0-2]\d|3[01])"$/';
                 if (!preg_match($dateRegex, $args['from'][0]) || !preg_match($dateRegex, $args['to'][0])) {
                     return array();
                 }
-                $where .= sprintf(' AND A.date >= %s AND  A.date <= %s', $this->db->quote_string($args['from'][0]), $this->db->quote_string($args['to'][0]));
+                $where .= sprintf(' AND A.date >= %s AND  A.date <= %s', $args['from'][0], $args['to'][0]);
             }
 
             if (isset($args['limit'])) {

--- a/helper.php
+++ b/helper.php
@@ -146,9 +146,9 @@ class helper_plugin_do extends DokuWiki_Plugin
             }
 
             if (isset($args['from']) && isset($args['to'])) {
-                $from = $args['from'][0];
-                $to =  $args['to'][0];
-                $where .= " AND A.date >= '$from' AND A.date <= '$to'";
+                $from = strtotime($args['from'][0], 0);
+                $to =  strtotime($args['to'][0], 0);
+                $where .= " AND strftime('%s',A.date, 'utc') >= '$from' AND strftime('%s',A.date, 'utc') <= '$to'";
             }
 
             if (isset($args['limit'])) {

--- a/helper.php
+++ b/helper.php
@@ -146,9 +146,12 @@ class helper_plugin_do extends DokuWiki_Plugin
             }
 
             if (isset($args['from']) && isset($args['to'])) {
-                $from = strtotime($args['from'][0], 0);
-                $to =  strtotime($args['to'][0], 0);
-                $where .= " AND strftime('%s',A.date, 'utc') >= '$from' AND strftime('%s',A.date, 'utc') <= '$to'";
+                // regex to match YYYY-MM-DD
+                $dateRegex = '/^\d{4}-([0]\d|1[0-2])-([0-2]\d|3[01])$/';
+                if (!preg_match($dateRegex, $args['from'][0]) || !preg_match($dateRegex, $args['to'][0])) {
+                    return array();
+                }
+                $where .= sprintf(' AND A.date >= %s AND  A.date <= %s', $this->db->quote_string($args['from'][0]), $this->db->quote_string($args['to'][0]));
             }
 
             if (isset($args['limit'])) {

--- a/helper.php
+++ b/helper.php
@@ -147,11 +147,11 @@ class helper_plugin_do extends DokuWiki_Plugin
 
             if (isset($args['from']) && isset($args['to'])) {
                 // regex to match YYYY-MM-DD
-                $dateRegex = '/^"\d{4}-([0]\d|1[0-2])-([0-2]\d|3[01])"$/';
+                $dateRegex = '/^\d{4}-([0]\d|1[0-2])-([0-2]\d|3[01])$/';
                 if (!preg_match($dateRegex, $args['from'][0]) || !preg_match($dateRegex, $args['to'][0])) {
                     return array();
                 }
-                $where .= sprintf(' AND A.date >= %s AND  A.date <= %s', $args['from'][0], $args['to'][0]);
+                $where .= sprintf(" AND A.date >= '%s' AND  A.date <= '%s' ", $args['from'][0], $args['to'][0]);
             }
 
             if (isset($args['limit'])) {


### PR DESCRIPTION
I added a query filter to allow an input of 'to' and 'from' dates into the dolist wiki text, in order to allow users to query tasks from a specific period.

For example:
{{dolist>NAMESPACE?id=ID&status=(DONE|UNDONE)&from=YYYY-MM-DD&to=YYYY-MM-DD}}

Currently, the period query requires both 'from' and 'to' date inputs.

